### PR TITLE
Allow PUTs to the resize image bucket

### DIFF
--- a/cf-resize-lambda.yml
+++ b/cf-resize-lambda.yml
@@ -57,6 +57,8 @@ Resources:
               - "*"
             AllowedMethods:
               - GET
+              - PUT
+              - POST
             AllowedOrigins:
               - "*"
             MaxAge: 3000


### PR DESCRIPTION
CORS issue. Not sure why this wasn't captured from the existing bucket.